### PR TITLE
Short flags for port & speed, naming, spacing and comments

### DIFF
--- a/cmd/tkey-runapp/main.go
+++ b/cmd/tkey-runapp/main.go
@@ -23,32 +23,41 @@ var le = log.New(os.Stderr, "", 0)
 
 var version string
 
-func main() {
-	var fileName, devPath, fileUSS string
-	var speed int
-	var enterUSS, verbose, helpOnly bool
-	pflag.CommandLine.SetOutput(os.Stderr)
-	pflag.CommandLine.SortFlags = false
-	pflag.StringVar(&devPath, "port", "",
-		"Set serial port device `PATH`. If this is not passed, auto-detection will be attempted.")
-	pflag.IntVar(&speed, "speed", tkeyclient.SerialSpeed,
-		"Set serial port speed in `BPS` (bits per second).")
-	pflag.BoolVar(&enterUSS, "uss", false,
-		"Enable typing of a phrase to be hashed as the User Supplied Secret. The USS is loaded onto the TKey along with the app itself and used by the firmware, together with other material, for deriving secrets for the application.")
-	pflag.StringVar(&fileUSS, "uss-file", "",
-		"Read `FILE` and hash its contents as the USS. Use '-' (dash) to read from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).")
-	pflag.BoolVar(&verbose, "verbose", false, "Enable verbose output.")
-	pflag.BoolVar(&helpOnly, "help", false, "Output this help.")
-	versionOnly := pflag.BoolP("version", "v", false, "Output version information.")
-	pflag.Usage = func() {
-		desc := fmt.Sprintf(`Usage: %[1]s [flags...] FILE
+const usage = `Usage: %[1]s [flags...] FILE
 
 %[1]s loads an application binary from FILE onto Tillitis TKey
 and starts it.
 
 Exit status code is 0 if the app is both successfully loaded and started. Exit
 code is non-zero if anything goes wrong, for example if TKey is already
-running some app.`, os.Args[0])
+running some app.`
+
+func main() {
+	var fileName, devPath, fileUSS string
+	var speed int
+	var enterUSS, verbose, helpOnly bool
+
+	pflag.CommandLine.SetOutput(os.Stderr)
+	pflag.CommandLine.SortFlags = false
+
+	pflag.StringVarP(&devPath, "port", "p", "",
+		"Set serial port device `PATH`. If this is not passed, auto-detection will be attempted.")
+
+	pflag.IntVarP(&speed, "speed", "s", tkeyclient.SerialSpeed,
+		"Set serial port speed in `BPS` (bits per second).")
+
+	pflag.BoolVar(&enterUSS, "uss", false,
+		"Enable typing of a phrase to be hashed as the User Supplied Secret. The USS is loaded onto the TKey along with the app itself and used by the firmware, together with other material, for deriving secrets for the application.")
+
+	pflag.StringVar(&fileUSS, "uss-file", "",
+		"Read `FILE` and hash its contents as the USS. Use '-' (dash) to read from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).")
+
+	pflag.BoolVar(&verbose, "verbose", false, "Enable verbose output.")
+	pflag.BoolVar(&helpOnly, "help", false, "Output this help.")
+	versionOnly := pflag.BoolP("version", "v", false, "Output version information.")
+
+	pflag.Usage = func() {
+		desc := fmt.Sprintf(usage, os.Args[0])
 		le.Printf("%s\n\n%s", desc,
 			pflag.CommandLine.FlagUsagesWrapped(86))
 	}

--- a/cmd/tkey-runapp/main.go
+++ b/cmd/tkey-runapp/main.go
@@ -47,7 +47,7 @@ func main() {
 		"Set serial port speed in `BPS` (bits per second).")
 
 	pflag.BoolVar(&enterUSS, "uss", false,
-		"Enable typing of a phrase to be hashed as the User Supplied Secret. The USS is loaded onto the TKey along with the app itself and used by the firmware, together with other material, for deriving secrets for the application.")
+		"Enable typing of a phrase to be hashed as the User Supplied uss. The USS is loaded onto the TKey along with the app itself and used by the firmware, together with other material, for deriving usss for the application.")
 
 	pflag.StringVar(&fileUSS, "uss-file", "",
 		"Read `FILE` and hash its contents as the USS. Use '-' (dash) to read from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).")
@@ -162,18 +162,19 @@ func main() {
 
 	fmt.Printf("UDI: %v\n", udi)
 
-	var secret []byte
+	// User Supplied Secret (USS)
+	var uss []byte
 
 	// If the USS flag is set -> read the USS from the user.
 	// If the USS file flag is set -> read the USS from the file.
 	if enterUSS {
-		secret, err = tkeyutil.InputUSS()
+		uss, err = tkeyutil.InputUSS()
 		if err != nil {
 			le.Printf("Failed to get USS: %v\n", err)
 			exit(1)
 		}
 	} else if fileUSS != "" {
-		secret, err = tkeyutil.ReadUSS(fileUSS)
+		uss, err = tkeyutil.ReadUSS(fileUSS)
 		if err != nil {
 			le.Printf("Failed to read uss-file %s: %v", fileUSS, err)
 			exit(1)
@@ -182,7 +183,7 @@ func main() {
 
 	le.Printf("Loading app from %v onto device\n", fileName)
 
-	err = tk.LoadApp(appBin, secret)
+	err = tk.LoadApp(appBin, uss)
 	if err != nil {
 		le.Printf("LoadAppFromFile failed: %v\n", err)
 		exit(1)

--- a/cmd/tkey-runapp/main.go
+++ b/cmd/tkey-runapp/main.go
@@ -33,14 +33,14 @@ code is non-zero if anything goes wrong, for example if TKey is already
 running some app.`
 
 func main() {
-	var fileName, devPath, fileUSS string
+	var fileName, serialPath, fileUSS string
 	var speed int
 	var enterUSS, verbose, helpOnly bool
 
 	pflag.CommandLine.SetOutput(os.Stderr)
 	pflag.CommandLine.SortFlags = false
 
-	pflag.StringVarP(&devPath, "port", "p", "",
+	pflag.StringVarP(&serialPath, "port", "p", "",
 		"Set serial port device `PATH`. If this is not passed, auto-detection will be attempted.")
 
 	pflag.IntVarP(&speed, "speed", "s", tkeyclient.SerialSpeed,
@@ -116,8 +116,8 @@ func main() {
 	}
 
 	// Try to auto-detect the serial port if not explicitly set.
-	if devPath == "" {
-		devPath, err = tkeyclient.DetectSerialPort(true)
+	if serialPath == "" {
+		serialPath, err = tkeyclient.DetectSerialPort(true)
 		if err != nil {
 			os.Exit(1)
 		}
@@ -125,9 +125,9 @@ func main() {
 
 	// Initialize the client and connect to the device.
 	tk := tkeyclient.New()
-	le.Printf("Connecting to device on serial port %s ...\n", devPath)
-	if err = tk.Connect(devPath, tkeyclient.WithSpeed(speed)); err != nil {
-		le.Printf("Could not open %s: %v\n", devPath, err)
+	le.Printf("Connecting to device on serial port %s ...\n", serialPath)
+	if err = tk.Connect(serialPath, tkeyclient.WithSpeed(speed)); err != nil {
+		le.Printf("Could not open %s: %v\n", serialPath, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Introduces changes related to clarity as well as short flags for port and speed (-p & -s). Only tested against qemu as i do not hade a key yet.