### PR TITLE
Introduce tkey-app-builder build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 [![ci](https://github.com/tillitis/tkey-devtools/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/tillitis/tkey-devtools/actions/workflows/ci.yaml)
 
-# tkey-tools
+# tkey-devtools
 
-This repository contains some development tools for the
-[Tillitis](https://tillitis.se/) TKey USB security stick.
+Some development tools for the [Tillitis](https://tillitis.se/) TKey
+USB security stick.
 
 - `tkey-runapp`: A simple development tool to load and start any TKey
   device app.
 
-- `run-tkey-qemu`: Script around our [TKey
-  emulator](https://github.com/tillitis/qemu) OCI image
-  `ghcr.io/tillitis/tkey-qemu-tk1-23.03.1`.
+- Source to build and run OCI images for apps development in C
+  (device) and Go (client): tkey-app-builder. See `contrib`.
+
+- Source to build an OCI image of the QEMU-based [TKey
+  emulator](https://github.com/tillitis/qemu). See `contrib`.
+
+- `run-tkey-qemu`: A script to run the above in a container and export
+  the the serial port as a pty outside the container.
 
 See the [TKey Developer Handbook](https://dev.tillitis.se/) for how to
 develop your own apps, how to run and debug them in the emulator or on
@@ -34,23 +39,18 @@ $ make
 If you want to use podman and you have `make` you can run:
 
 ```
-$ podman pull ghcr.io/tillitis/tkey-builder:2
+$ podman pull ghcr.io/tillitis/tkey-builder
 $ make podman
 ```
 
-or run podman directly with
-
-```
-$ podman run --rm --mount type=bind,source=.,target=/src -w /src -it ghcr.io/tillitis/tkey-builder:2 make -j
-```
-
-To install:
+To install under Linux:
 
 ```
 sudo make install
 ```
 
-If you want to reload the udev rules to access the TKey use:
+Note that this installs Linux udev rules to enable you to access the
+TKey. If you want to reload the udev rules to access the TKey use:
 
 ```
 sudo make reload-rules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![ci](https://github.com/tillitis/tkey-devtools/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/tillitis/tkey-devtools/actions/workflows/ci.yaml)
 
 # tkey-tools
@@ -9,8 +8,8 @@ This repository contains some development tools for the
 - `tkey-runapp`: A simple development tool to load and start any TKey
   device app.
 
-- `run-tkey-qemu`: Script around our 
-  [TKey emulator](https://github.com/tillitis/qemu) OCI image
+- `run-tkey-qemu`: Script around our [TKey
+  emulator](https://github.com/tillitis/qemu) OCI image
   `ghcr.io/tillitis/tkey-qemu-tk1-23.03.1`.
 
 See the [TKey Developer Handbook](https://dev.tillitis.se/) for how to

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -1,0 +1,49 @@
+# Copyright (C) 2022, 2023 - Tillitis AB
+# SPDX-License-Identifier: GPL-2.0-only
+
+# image produced by build-image targets
+BUILDQEMUIMAGE=qemu-local
+BUILDAPPIMAGE=tkey-app-builder-local
+
+# default images used when running a container
+APPIMAGE=tkey-app-builder-local
+EMUIMAGE=ghcr.io/tillitis/tkey-qemu-tk1-23.03.1
+
+help: all
+
+all:
+	@echo "Targets:"
+	@echo "run-app               Run a shell using image '$(APPIMAGE)' for app development"
+	@echo "pull-app              Pull down the image '$(APPIMAGE)'"
+	@echo "build-app-image       Build a development image named '$(BUILDAPPIMAGE)'"
+	@echo "                      A newly built image can be used like: make IMAGE=$(BUILDAPPIMAGE) run"
+
+
+	@echo "run-emu               Run a shell using image '$(EMUIMAGE)' for the TKey emulator"
+	@echo "pull-emu              Pull down the image '$(EMUIMAGE)'"
+	@echo "build-emu-image       Build a toolchain image named '$(BUILDEMUIMAGE)'"
+	@echo "                      A newly built image can be used like: make IMAGE=$(BUILDEMUIMAGE) run"
+
+.PHONY: run-app
+run-app:
+	podman run --rm --mount type=bind,source="`pwd`/../",target=/build -w /build -it $(BUILDAPPIMAGE)
+
+.PHONY: pull-app
+pull-app:
+	podman pull $(APPIMAGE)
+
+.PHONY: build-app-image
+build-app-image:
+	podman build -t $(BUILDAPPIMAGE) -f tkey-app-builder.dockerfile
+
+.PHONY: run-emu
+run-emu:
+	podman run --rm --mount type=bind,source="`pwd`/../",target=/build -w /build -it $(EMUIMAGE)
+
+.PHONY: pull-emu
+pull-emu:
+	podman pull $(EMUIMAGE)
+
+.PHONY: build-emu-image
+build-emu-image:
+	podman build -t $(EMUIMAGE) -f tkey-qemu.dockerfile

--- a/contrib/tkey-app-builder.dockerfile
+++ b/contrib/tkey-app-builder.dockerfile
@@ -1,0 +1,12 @@
+# Copyright (C) 2024 Tillitis AB
+# SPDX-License-Identifier: GPL-2.0-only
+
+FROM alpine:3.20
+
+RUN apk add --no-cache \
+    clang \
+    clang-extra-tools \
+    go \
+    lld \
+    llvm \
+    make

--- a/contrib/tkey-qemu.dockerfile
+++ b/contrib/tkey-qemu.dockerfile
@@ -5,38 +5,37 @@
 # the firmware that our TKey/QEMU will run. The published tkey-qemu image will
 # have this as part of its name, the tag is then used for versioning the image
 # (could be updates to the TKey QEMU machine).
-ARG TKEYREPO_TAG=TK1-23.03.1
+ARG TKEYREPO_TAG=TK1-23.03.2
 
 # This is what we'll actually checkout when building the firmware. It
 # really is the firmware as of the TK1-tag above, but a couple of
 # commits later where the firmware checksum was committed!
-ARG TKEYREPO_TREEISH=444ee3d26c3acf651ff1bbb12023034ccee6ed68
+#ARG TKEYREPO_TREEISH=444ee3d26c3acf651ff1bbb12023034ccee6ed68
 
 # Using tkey-builder image for building since it has the deps.
-FROM ghcr.io/tillitis/tkey-builder:2 AS builder
+#FROM ghcr.io/tillitis/tkey-builder:2 AS builder
+FROM tkey-app-builder-local AS builder
 
-ARG TKEYREPO_TREEISH
-
-# Cleaning up /usr/local since we will later COPY all from there
-RUN rm -rf \
-    /usr/local/bin/* \
-    /usr/local/pico-sdk \
-    /usr/local/repo-commit-* \
-    /usr/local/share/icebox \
-    /usr/local/share/yosys
+RUN apk add --no-cache \
+    bash \
+    git \
+    glib-dev \
+    ninja \
+    python3 \
+    py3-virtualenv
 
 RUN git clone -b tk1 --depth=1 https://github.com/tillitis/qemu /src/qemu \
     && mkdir /src/qemu/build
 WORKDIR /src/qemu/build
 RUN ../configure --target-list=riscv32-softmmu --disable-werror \
-    && make -j "$(nproc --ignore=2)" \
+    && make -j "$(nproc --ignore=2)" qemu-system-riscv32 \
     && make install \
     && git >/usr/local/repo-commit-tillitis--qemu describe --all --always --long --dirty
 
 RUN git clone https://github.com/tillitis/tillitis-key1 /src/tkey
 WORKDIR /src/tkey/hw/application_fpga
 # QEMU needs the .elf, but we build .bin to check sum
-RUN git checkout ${TKEYREPO_TREEISH} \
+RUN git checkout ${TKEYREPO_TAG} \
     && make firmware.bin && sha512sum -c firmware.bin.sha512 \
     && make firmware.elf && cp -af firmware.elf firmware-noconsole.elf \
     && make clean \

--- a/contrib/tkey-qemu.dockerfile
+++ b/contrib/tkey-qemu.dockerfile
@@ -1,3 +1,5 @@
+# Copyright (C) 2023 Tillitis AB
+# SPDX-License-Identifier: GPL-2.0-only
 
 # This is the tag in the https://github.com/tillitis/tillitis-key1 repo with
 # the firmware that our TKey/QEMU will run. The published tkey-qemu image will

--- a/tools/spdx-ensure
+++ b/tools/spdx-ensure
@@ -22,7 +22,6 @@ missingok_files=(
 LICENSE
 Makefile
 README.md
-tkey-qemu.dockerfile
 go.mod
 go.sum
 gon.hcl


### PR DESCRIPTION
## Description

Containerfile for tkey-app-builder. Moves the qemu dockerfile to contrib as well, adds make targets, and updates docs accordingly.

Note that the make target doesn't successfully build the qemu OCI image. This is true also for trying to build the qemu image from the dockerfile in the main branch! See #8.

A temporary fix to build qemu with the new tkey-app-builder is included in this PR. I don't know if we can use that somehow.

Relates to https://github.com/tillitis/tillitis-key1/issues/272

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Feature (non breaking change which adds functionality)
- [x] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
