### PR TITLE
Hidread: add enumeration and opening of a specified port

### DIFF
--- a/cmd/hidread/main.go
+++ b/cmd/hidread/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/sstallion/go-hid"
 )
@@ -39,6 +40,9 @@ func main() {
 	size := flag.Int("s", 64, "Size of Input Reports to read")
 	versionOnly := flag.Bool("v", false, "Output version information.")
 	enumerate := flag.Bool("e", false, "Enumerate devices.")
+	vid := flag.Uint("vid", 0, "VID for device to open.")
+	pid := flag.Uint("pid", 0, "PID for device to open.")
+	continue_search := flag.Bool("c", false, "Continue scanning for device with specified VID and PID, open when it appears.")
 
 	flag.Parse()
 
@@ -51,7 +55,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *help || *path == "" {
+	if *help {
 		flag.Usage()
 		os.Exit(0)
 	}
@@ -66,6 +70,36 @@ func main() {
 				info.ProductStr)
 			return nil
 		})
+		os.Exit(0)
+	}
+
+	var hid_dev hid.DeviceInfo
+	if *vid != 0 && *pid != 0 {
+		for {
+			hid.Enumerate(uint16(*vid), uint16(*pid), func(info *hid.DeviceInfo) error {
+				fmt.Printf("%s: ID %04x:%04x %s %s\n",
+					info.Path,
+					info.VendorID,
+					info.ProductID,
+					info.MfrStr,
+					info.ProductStr)
+				hid_dev = *info
+
+				return nil
+			})
+
+			*path = hid_dev.Path
+
+			if *path != "" || !*continue_search {
+				break
+			}
+			time.Sleep(1 * time.Second)
+			fmt.Printf("Searching..\n")
+		}
+	}
+
+	if *path == "" {
+		fmt.Printf("Path empty\n")
 		os.Exit(0)
 	}
 

--- a/cmd/hidread/main.go
+++ b/cmd/hidread/main.go
@@ -38,6 +38,7 @@ func main() {
 	path := flag.String("f", "", "File path to device")
 	size := flag.Int("s", 64, "Size of Input Reports to read")
 	versionOnly := flag.Bool("v", false, "Output version information.")
+	enumerate := flag.Bool("e", false, "Enumerate devices.")
 
 	flag.Parse()
 
@@ -52,6 +53,19 @@ func main() {
 
 	if *help || *path == "" {
 		flag.Usage()
+		os.Exit(0)
+	}
+
+	if *enumerate {
+		hid.Enumerate(hid.VendorIDAny, hid.ProductIDAny, func(info *hid.DeviceInfo) error {
+			fmt.Printf("%s: ID %04x:%04x %s %s\n",
+				info.Path,
+				info.VendorID,
+				info.ProductID,
+				info.MfrStr,
+				info.ProductStr)
+			return nil
+		})
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
## Description

Adds the features to:
- Enumerate all connected HID devices
- Scan after a specific VID/PID device, and optionally continue to scan and open the port if it is found. 

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.
- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
