### PR TITLE
Update tkeyclient to handle TKey Unlocked like Bellatrix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## v0.0.3
+
+- Update tkeyclient to v1.3.1 to handle TKey Unlocked (product ID 8)
+  as a Bellatrix when it comes to USS digest handling.
+
+- Only allow `--force-full-uss` when either `--uss` or `--uss-file` is
+  used.
+
+Full
+[changelog](https://github.com/tillitis/tkey-devtools/compare/v0.0.2...v0.0.3).
+
 ## v0.0.2
 
 - Update tkeyclient version because of a vulnerability leaving some

--- a/cmd/tkey-runapp/go.mod
+++ b/cmd/tkey-runapp/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/spf13/pflag v1.0.5
-	github.com/tillitis/tkeyclient v1.3.0
+	github.com/tillitis/tkeyclient v1.3.1
 	github.com/tillitis/tkeyutil v0.0.9
 )
 

--- a/cmd/tkey-runapp/go.sum
+++ b/cmd/tkey-runapp/go.sum
@@ -26,6 +26,8 @@ github.com/tillitis/tkeyclient v1.2.0 h1:X/PjUPK061EFNmf3V4knb20wTfcIuUH13VSC/0V
 github.com/tillitis/tkeyclient v1.2.0/go.mod h1:4TiEj0qUwaffmOODPZro6cUBaw+Gb6F5EFd6tcH7UXE=
 github.com/tillitis/tkeyclient v1.3.0 h1:fUlghD+xvtL+qoajgrsetCC7KPwSfpjDDgqxMOBA2VU=
 github.com/tillitis/tkeyclient v1.3.0/go.mod h1:7VtzyEjm08Wf+1zdrs20HsvM+WzhyztinvGG2/HY+Is=
+github.com/tillitis/tkeyclient v1.3.1 h1:IouMAtwwXewhXLmcySBmXuyFuI4WoAw8NQj+gFWlLaw=
+github.com/tillitis/tkeyclient v1.3.1/go.mod h1:7VtzyEjm08Wf+1zdrs20HsvM+WzhyztinvGG2/HY+Is=
 github.com/tillitis/tkeyutil v0.0.9 h1:WWF4Emxch32TczYjjYwl45GMtxsD9l8432mZaX6u8mw=
 github.com/tillitis/tkeyutil v0.0.9/go.mod h1:+vxU9HmwR2pdPRYg1YlmWW46h2XADdSAhCGUQCryzJg=
 go.bug.st/serial v1.6.2 h1:kn9LRX3sdm+WxWKufMlIRndwGfPWsH1/9lCWXQCasq8=

--- a/cmd/tkey-runapp/main.go
+++ b/cmd/tkey-runapp/main.go
@@ -95,6 +95,12 @@ running some app.`, os.Args[0])
 		os.Exit(2)
 	}
 
+	if forceFullUss && fileUSS == "" != enterUSS {
+		le.Printf("--force-full-uss unusable unless you also specify --uss or --uss-file.\n\n")
+		pflag.Usage()
+		os.Exit(2)
+	}
+
 	appBin, err := os.ReadFile(fileName)
 	if err != nil {
 		le.Printf("Failed to read file: %v\n", err)


### PR DESCRIPTION
## Description

- Update tkeyclient
- Only allow `--force-full-uss` with `--uss` or `--uss-file`

## Type of change

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
