### PR TITLE
Fix use of DESTDIR to not add extra slashes (/)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ endif
 .PHONY: all
 all: tkey-runapp
 
-DESTDIR=/
+DESTDIR=
 PREFIX=/usr/local
 UDEVDIR=/etc/udev
-destbin=$(DESTDIR)/$(PREFIX)/bin
-destrules=$(DESTDIR)/$(UDEVDIR)/rules.d
+destbin=$(DESTDIR)$(PREFIX)/bin
+destrules=$(DESTDIR)$(UDEVDIR)/rules.d
 .PHONY: install
 install:
 	install -Dm755 tkey-runapp $(destbin)/tkey-runapp


### PR DESCRIPTION
## Description

As described in #21, standard convention is that DESTDIR is default empty, and when set, prepended to install paths without any extra slashes.

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
