### PR TITLE
Update QEmu dockerfile to use latest Bellatrix firmware and QEmu

### DIFF
--- a/tkey-qemu.dockerfile
+++ b/tkey-qemu.dockerfile
@@ -9,7 +9,12 @@ ARG TKEYREPO_TAG=TK1-24.03
 # should be the release commit.
 ARG TKEYREPO_TREEISH=1c90b1aa3dbfb4e62039683ee6049ae8af608498
 
+# This is what we'll checkout when building QEmu
+ARG QEMUREPO_TREEISH=d8413fe3d93daee611cb737a52819cb2cb89976d
+
 FROM docker.io/library/ubuntu:24.04 as qemu-builder
+
+ARG QEMUREPO_TREEISH
 
 RUN apt-get -qq update -y \
     && DEBIAN_FRONTEND=noninteractive \
@@ -27,7 +32,8 @@ RUN rm -rf \
     /usr/local/bin/* \
     /usr/local/repo-commit-*
 
-RUN git clone -b tk1 --depth=1 https://github.com/tillitis/qemu /src/qemu \
+RUN git clone -b tk1 --single-branch https://github.com/tillitis/qemu /src/qemu \
+    && (cd /src/qemu && git checkout ${QEMUREPO_TREEISH}) \
     && mkdir /src/qemu/build
 WORKDIR /src/qemu/build
 RUN ../configure --target-list=riscv32-softmmu --disable-werror \

--- a/tkey-qemu.dockerfile
+++ b/tkey-qemu.dockerfile
@@ -62,9 +62,11 @@ RUN apt-get -qq update -y \
                libglib2.0-0 \
                libusb-1.0-0 \
                libpixman-1-0 \
+               python3 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=qemu-builder /usr/local/ /usr/local
+COPY --from=qemu-builder /src/qemu/tools/tk1/qemu_usb_mux.py /usr/local/bin/
 COPY --from=firmware-builder /usr/local/repo-commit-tillitis--key1 /usr/local/
 COPY --from=firmware-builder /src/tkey/hw/application_fpga/firmware-noconsole.elf /tkey-firmware-noconsole.elf
 COPY --from=firmware-builder /src/tkey/hw/application_fpga/firmware-console.elf   /tkey-firmware-console.elf

--- a/tkey-qemu.dockerfile
+++ b/tkey-qemu.dockerfile
@@ -9,18 +9,23 @@ ARG TKEYREPO_TAG=TK1-24.03
 # should be the release commit.
 ARG TKEYREPO_TREEISH=1c90b1aa3dbfb4e62039683ee6049ae8af608498
 
-# Using tkey-builder image for building since it has the deps.
-FROM ghcr.io/tillitis/tkey-builder:4 AS builder
+FROM docker.io/library/ubuntu:24.04 as qemu-builder
 
-ARG TKEYREPO_TREEISH
+RUN apt-get -qq update -y \
+    && DEBIAN_FRONTEND=noninteractive \
+       apt-get install -y --no-install-recommends \
+               build-essential \
+               ca-certificates \
+               git \
+               libglib2.0-dev \
+               ninja-build \
+               python3 \
+               python3-venv
 
 # Cleaning up /usr/local since we will later COPY all from there
 RUN rm -rf \
     /usr/local/bin/* \
-    /usr/local/pico-sdk \
-    /usr/local/repo-commit-* \
-    /usr/local/share/icebox \
-    /usr/local/share/yosys
+    /usr/local/repo-commit-*
 
 RUN git clone -b tk1 --depth=1 https://github.com/tillitis/qemu /src/qemu \
     && mkdir /src/qemu/build
@@ -29,6 +34,10 @@ RUN ../configure --target-list=riscv32-softmmu --disable-werror \
     && make -j "$(nproc --ignore=2)" \
     && make install \
     && git >/usr/local/repo-commit-tillitis--qemu describe --all --always --long --dirty
+
+FROM ghcr.io/tillitis/tkey-builder:4 AS firmware-builder
+
+ARG TKEYREPO_TREEISH
 
 RUN git clone https://github.com/tillitis/tillitis-key1 /src/tkey
 WORKDIR /src/tkey/hw/application_fpga
@@ -43,7 +52,7 @@ RUN git checkout ${TKEYREPO_TREEISH} \
 
 
 # Our QEMU "runtime" image
-FROM docker.io/library/ubuntu:22.10
+FROM docker.io/library/ubuntu:24.04
 
 ARG TKEYREPO_TAG
 
@@ -55,9 +64,10 @@ RUN apt-get -qq update -y \
                libpixman-1-0 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/local/ /usr/local
-COPY --from=builder /src/tkey/hw/application_fpga/firmware-noconsole.elf /tkey-firmware-noconsole.elf
-COPY --from=builder /src/tkey/hw/application_fpga/firmware-console.elf   /tkey-firmware-console.elf
+COPY --from=qemu-builder /usr/local/ /usr/local
+COPY --from=firmware-builder /usr/local/repo-commit-tillitis--key1 /usr/local/
+COPY --from=firmware-builder /src/tkey/hw/application_fpga/firmware-noconsole.elf /tkey-firmware-noconsole.elf
+COPY --from=firmware-builder /src/tkey/hw/application_fpga/firmware-console.elf   /tkey-firmware-console.elf
 
 CMD [ "qemu-system-riscv32" \
     , "-nographic" \

--- a/tkey-qemu.dockerfile
+++ b/tkey-qemu.dockerfile
@@ -3,15 +3,14 @@
 # the firmware that our TKey/QEMU will run. The published tkey-qemu image will
 # have this as part of its name, the tag is then used for versioning the image
 # (could be updates to the TKey QEMU machine).
-ARG TKEYREPO_TAG=TK1-23.03.1
+ARG TKEYREPO_TAG=TK1-24.03
 
 # This is what we'll actually checkout when building the firmware. It
-# really is the firmware as of the TK1-tag above, but a couple of
-# commits later where the firmware checksum was committed!
-ARG TKEYREPO_TREEISH=444ee3d26c3acf651ff1bbb12023034ccee6ed68
+# should be the release commit.
+ARG TKEYREPO_TREEISH=1c90b1aa3dbfb4e62039683ee6049ae8af608498
 
 # Using tkey-builder image for building since it has the deps.
-FROM ghcr.io/tillitis/tkey-builder:2 AS builder
+FROM ghcr.io/tillitis/tkey-builder:4 AS builder
 
 ARG TKEYREPO_TREEISH
 


### PR DESCRIPTION
## Description

This PR updates the QEmu-image dockerfile to use latest Bellatrix firmware (TK1-24.03) and latest Tillitis QEmu.

To get latest QEmu to build the builder stage is split into two (qemu-builder and firmware-builder) and QEmu is built with Ubuntu 24.04. Firmware is built with tkey-builder:4.

An image is available here: ghcr.io/tillitis/tkey-qemu-tk1-24.03:alpha2

When this PR is merged the image can be tagged `tkey-qemu-tk1-24.03:1` and `run-tkey-qemu` can be updated accordingly.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
