### PR TITLE
feat: add --reset flag to tkey-runapp

### DIFF
--- a/cmd/tkey-runapp/main.go
+++ b/cmd/tkey-runapp/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/tillitis/tkeyclient"
@@ -23,10 +25,64 @@ var le = log.New(os.Stderr, "", 0)
 
 var version string
 
+type appCmd struct {
+	code   byte
+	name   string
+	cmdLen tkeyclient.CmdLen
+}
+
+func (c appCmd) Code() byte {
+	return c.code
+}
+
+func (c appCmd) CmdLen() tkeyclient.CmdLen {
+	return c.cmdLen
+}
+
+func (c appCmd) Endpoint() tkeyclient.Endpoint {
+	return tkeyclient.DestApp
+}
+
+func (c appCmd) String() string {
+	return c.name
+}
+
+var (
+	cmdReset = appCmd{0xfe, "cmdReset", tkeyclient.CmdLen4}
+)
+
+type fwResetType uint8
+
+// FW reset types
+const (
+	fwResetTypeStartDefault fwResetType = 0 // Boot from flash slot 0
+	// fwResetTypeStartFlash0 fwResetType = 1 // Boot from flash slot 0 (same as default)
+	fwResetTypeStartFlash1 fwResetType = 2 // Boot from flash slot 1
+	// fwResetTypeStartFlash0Ver fwResetType = 3 // Not implemented currently
+	// fwResetTypeStartFlash1Ver fwResetType = 4 // Not implemented currently
+	fwResetTypeStartClient fwResetType = 5 // Load app from client
+	// fwResetTypeStartClientVer fwResetType = 6 // Not implemented currently
+	fwResetTypeStartInvalid fwResetType = 255
+)
+
+type bvActionType uint8
+
+// Boot verifier action types
+const (
+	bvActionTypeApp1    bvActionType = 0 // Verify app in flash slot 1
+	bvActionTypeCmdMode bvActionType = 1 // Wait for command from host
+	bvActionTypeInvalid bvActionType = 255
+)
+
 func main() {
-	var fileName, devPath, fileUSS string
+	var fileName, devPath, fileUSS, fwResetStr, bvActionStr string
 	var speed int
+	var fwReset fwResetType
+	var bvAction bvActionType
+	var appBin []byte
+	var secret []byte
 	var enterUSS, verbose, helpOnly, forceFullUss bool
+	var err error
 	pflag.CommandLine.SetOutput(os.Stderr)
 	pflag.CommandLine.SortFlags = false
 	pflag.StringVar(&devPath, "port", "",
@@ -37,6 +93,10 @@ func main() {
 	pflag.StringVar(&fileUSS, "uss-file", "",
 		"Read `FILE` and hash its contents as the USS. Use '-' (dash) to read from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).")
 	pflag.BoolVar(&forceFullUss, "force-full-uss", false, "Force use of 32 byte USS digest.")
+	pflag.StringVar(&fwResetStr, "reset", "",
+		"Send reset `TYPE`. Can be:\ndefault (boot from flash slot 0)\nflash1 (boot from flash slot 1)\nclient (load app from client)")
+	pflag.StringVar(&bvActionStr, "bv", "",
+		"Optional for reset. If boot-verifier (normally in flash slot 0) will run after reset, use `ACTION`. Can be:\napp1 (verify app in flash slot 1)\ncmdmode (wait for command from client)")
 	pflag.BoolVar(&verbose, "verbose", false, "Enable verbose output.")
 	pflag.BoolVar(&helpOnly, "help", false, "Output this help.")
 	versionOnly := pflag.BoolP("version", "v", false, "Output version information.")
@@ -64,7 +124,7 @@ running some app.`, os.Args[0])
 		if pflag.NArg() > 1 {
 			le.Printf("Unexpected argument: %s\n\n", strings.Join(pflag.Args()[1:], " "))
 			pflag.Usage()
-			os.Exit(2)
+			os.Exit(1)
 		}
 		fileName = pflag.Args()[0]
 	}
@@ -79,10 +139,10 @@ running some app.`, os.Args[0])
 		os.Exit(0)
 	}
 
-	if fileName == "" {
+	if fileName == "" && fwResetStr == "" {
 		le.Printf("Please pass an app binary FILE.\n\n")
 		pflag.Usage()
-		os.Exit(2)
+		os.Exit(1)
 	}
 
 	if !verbose {
@@ -92,7 +152,7 @@ running some app.`, os.Args[0])
 	if enterUSS && fileUSS != "" {
 		le.Printf("Can't combine --uss and --uss-file\n\n")
 		pflag.Usage()
-		os.Exit(2)
+		os.Exit(1)
 	}
 
 	if forceFullUss && fileUSS == "" != enterUSS {
@@ -101,19 +161,39 @@ running some app.`, os.Args[0])
 		os.Exit(2)
 	}
 
-	appBin, err := os.ReadFile(fileName)
-	if err != nil {
-		le.Printf("Failed to read file: %v\n", err)
-		os.Exit(1)
-	}
-	if bytes.HasPrefix(appBin, []byte("\x7fELF")) {
-		le.Printf("%s looks like an ELF executable, but a raw binary is expected.\n", fileName)
-		os.Exit(1)
+	if fileName != "" {
+		appBin, err = os.ReadFile(fileName)
+		if err != nil {
+			le.Printf("Failed to read file: %v\n", err)
+			os.Exit(1)
+		}
+		if bytes.HasPrefix(appBin, []byte("\x7fELF")) {
+			le.Printf("%s looks like an ELF executable, but a raw binary is expected.\n", fileName)
+			os.Exit(1)
+		}
 	}
 
 	if devPath == "" {
 		devPath, err = tkeyclient.DetectSerialPort(true)
 		if err != nil {
+			os.Exit(1)
+		}
+	}
+
+	if fwResetStr != "" {
+		fwReset, err = parseFwReset(fwResetStr)
+		if err != nil {
+			le.Printf("%v\n\n", err)
+			pflag.Usage()
+			os.Exit(1)
+		}
+	}
+
+	if bvActionStr != "" {
+		bvAction, err = parseBvAction(bvActionStr)
+		if err != nil {
+			le.Printf("%v\n\n", err)
+			pflag.Usage()
 			os.Exit(1)
 		}
 	}
@@ -142,25 +222,26 @@ running some app.`, os.Args[0])
 	}
 	handleSignals(func() { exit(1) }, os.Interrupt, syscall.SIGTERM)
 
-	nameVer, err := tk.GetNameVersion()
-	if err != nil {
-		le.Printf("GetNameVersion failed: %v\n", err)
-		le.Printf("If the serial port is correct, then the TKey might not be in firmware-\n" +
-			"mode, and have an app running already. Please unplug and plug it in again.\n")
-		exit(1)
+	if fwResetStr == "" {
+		nameVer, err := tk.GetNameVersion()
+		if err != nil {
+			le.Printf("GetNameVersion failed: %v\n", err)
+			le.Printf("If the serial port is correct, then the TKey might not be in firmware-\n" +
+				"mode, and have an app running already. Please unplug and plug it in again.\n")
+			exit(1)
+		}
+		le.Printf("Firmware name0:'%s' name1:'%s' version:%d\n",
+			nameVer.Name0, nameVer.Name1, nameVer.Version)
+
+		udi, err := tk.GetUDI()
+		if err != nil {
+			le.Printf("GetUDI failed: %v\n", err)
+			exit(1)
+		}
+
+		le.Printf("UDI: %v\n", udi)
 	}
-	le.Printf("Firmware name0:'%s' name1:'%s' version:%d\n",
-		nameVer.Name0, nameVer.Name1, nameVer.Version)
 
-	udi, err := tk.GetUDI()
-	if err != nil {
-		le.Printf("GetUDI failed: %v\n", err)
-		exit(1)
-	}
-
-	fmt.Printf("UDI: %v\n", udi)
-
-	var secret []byte
 	if enterUSS {
 		secret, err = tkeyutil.InputUSS()
 		if err != nil {
@@ -171,6 +252,30 @@ running some app.`, os.Args[0])
 		secret, err = tkeyutil.ReadUSS(fileUSS)
 		if err != nil {
 			le.Printf("Failed to read uss-file %s: %v", fileUSS, err)
+			exit(1)
+		}
+	}
+
+	if fwResetStr != "" {
+		if bvActionStr == "" {
+			bvAction = bvActionTypeApp1
+		}
+		err = sendReset(tk, fwReset, bvAction)
+		if err != nil {
+			le.Printf("sendReset failed: %v\n", err)
+			exit(1)
+		}
+		if fileName == "" {
+			exit(0)
+		}
+		le.Printf("Waiting for CH552 to re-enumerate\n")
+		time.Sleep(3 * time.Second)
+		devPath, err = tkeyclient.DetectSerialPort(true)
+		if err != nil {
+			exit(1)
+		}
+		if err = tk.Connect(devPath, options...); err != nil {
+			le.Printf("Could not open %s: %v\n", devPath, err)
 			exit(1)
 		}
 	}
@@ -222,4 +327,56 @@ func readBuildInfo() string {
 		v = sb.String()
 	}
 	return v
+}
+
+func sendReset(tk *tkeyclient.TillitisKey, reset fwResetType, action bvActionType) error {
+	id := 0x01
+
+	tx, err := tkeyclient.NewFrameBuf(cmdReset, id)
+	if err != nil {
+		return fmt.Errorf("failed to create frame buffer: %w", err)
+	}
+
+	tx[2] = uint8(reset)
+	tx[3] = uint8(action)
+
+	tkeyclient.Dump("reset tx", tx)
+
+	if err = tk.Write(tx); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	return nil
+}
+
+func parseFwReset(input string) (fwResetType, error) {
+	switch input {
+	case "default":
+		return fwResetTypeStartDefault, nil
+	// case "flash0":
+	//	return fwResetTypeStartFlash0, nil
+	case "flash1":
+		return fwResetTypeStartFlash1, nil
+	// case "flash0verify":
+	//	return fwResetTypeStartFlash0Ver, nil
+	// case "flash1verify":
+	//	return fwResetTypeStartFlash1Ver, nil
+	case "client":
+		return fwResetTypeStartClient, nil
+	// case "clientverify":
+	//	return fwResetTypeStartClientVer, nil
+	default:
+		return fwResetTypeStartInvalid, errors.New("invalid --reset TYPE")
+	}
+}
+
+func parseBvAction(input string) (bvActionType, error) {
+	switch input {
+	case "app1":
+		return bvActionTypeApp1, nil
+	case "cmdmode":
+		return bvActionTypeCmdMode, nil
+	default:
+		return bvActionTypeInvalid, errors.New("invalid --bv ACTION")
+	}
 }


### PR DESCRIPTION
## Description

Add support for sending a reset command to a running TKey application before loading a new app, without requiring a manual replug.

- --reset TYPE: specifies the firmware reset type (default, flash1, client)
- --bv ACTION: optionally specifies the boot verifier action after reset (app1, cmdmode); defaults to app1 if not specified

When --reset is given without a file argument, the tool exits after sending the reset. When combined with a file argument, it waits 3 seconds for the device to re-enumerate before loading the app.

Firmware version and UDI are only queried when not sending a reset, since the device may be running an app rather than firmware in that case.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
